### PR TITLE
Option to cut out frames around keyframes to prevent awkward pauses + bugfix

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -452,7 +452,7 @@ class DynamiCrafterBatchInterpolation:
 
             if out_video.shape[1] != orig_H or out_video.shape[2] != orig_W:
                 out_video = F.interpolate(out_video.permute(0, 3, 1, 2), size=(orig_H, orig_W), mode="bicubic")
-                out_video = video.permute(0, 2, 3, 1)
+                out_video = out_video.permute(0, 2, 3, 1)
 
             # should we trim middle keyframes?
             if cut_near_keyframes > 0:


### PR DESCRIPTION
New value you can set to remove some frames around keyframes. Defaults to 0 for "normal" behavior. This fulfills this issue: https://github.com/kijai/ComfyUI-DynamiCrafterWrapper/issues/10

I also noticed a code bug when I was poking around (looks like "video" and "out_video" didn't get renamed properly).